### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -14,7 +14,10 @@ export class UsersService {
   ) {}
 
   async create (createUserDto: CreateUserDto) {
-    const userExists = await this.userRepository.findOne({ email: createUserDto.email })
+    if (typeof createUserDto.email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(createUserDto.email)) {
+      throw new HttpException('Invalid email format', HttpStatus.BAD_REQUEST)
+    }
+    const userExists = await this.userRepository.findOne({ email: { $eq: createUserDto.email } })
     if (!userExists) {
       createUserDto.password = hashSync(createUserDto.password)
       const userSaved = await this.userRepository.create(createUserDto)


### PR DESCRIPTION
Potential fix for [https://github.com/Dazantiga/bitcoin-wallet-api/security/code-scanning/3](https://github.com/Dazantiga/bitcoin-wallet-api/security/code-scanning/3)

To fix the issue, we need to ensure that the `email` field in the query object is treated as a literal value and not as a query object or special property. This can be achieved by using MongoDB's `$eq` operator, which forces the value to be interpreted as a literal. Additionally, we should validate the `email` field to ensure it is a string and matches a valid email format before using it in the query.

Steps to fix:
1. Use the `$eq` operator in the `findOne` query to ensure the `email` field is treated as a literal value.
2. Add validation logic to check that `createUserDto.email` is a valid string and matches an email format before constructing the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
